### PR TITLE
Pre-select a tool tab if it's passed in the url

### DIFF
--- a/js/tabs.js
+++ b/js/tabs.js
@@ -2,6 +2,10 @@ function setupToolsTabs() {
   var tabs = $('.tabs__top-bar li');
   var tabContents = $('.tabs__content');
 
+  // If we have a tool in the url fragement, pre-select it
+  if (location.hash && location.hash.length > 1)
+    selectToolInTabs(location.hash.substr(1));
+
   function clearTabsCurrent() {
     tabs.removeClass('current');
     tabContents.removeClass('current');
@@ -15,6 +19,15 @@ function setupToolsTabs() {
     $(this).addClass('current');
     $("#" + tab_id).addClass('current');
   });
+
+  // The following selects a tool tab in /guides/get-started
+  function selectToolInTabs(toolName) {
+    clearTabsCurrent();
+
+    var toolNameEscaped = $.escapeSelector(toolName);
+    $("li[data-tab='tab-install-" + toolNameEscaped + "']").addClass('current');
+    $('#tab-install-' + toolNameEscaped).addClass('current');
+  }
 }
 
 function setupOsTabs() {

--- a/js/tabs.js
+++ b/js/tabs.js
@@ -22,11 +22,15 @@ function setupToolsTabs() {
 
   // The following selects a tool tab in /guides/get-started
   function selectToolInTabs(toolName) {
-    clearTabsCurrent();
-
     var toolNameEscaped = $.escapeSelector(toolName);
-    $("li[data-tab='tab-install-" + toolNameEscaped + "']").addClass('current');
-    $('#tab-install-' + toolNameEscaped).addClass('current');
+
+    // Check this is a valid tool first, so we don't hide all tabs
+    if ($("li[data-tab='tab-install-" + toolNameEscaped + "']").length > 0) {
+      clearTabsCurrent();
+
+      $("li[data-tab='tab-install-" + toolNameEscaped + "']").addClass('current');
+      $('#tab-install-' + toolNameEscaped).addClass('current');
+    }
   }
 }
 


### PR DESCRIPTION
This allows editors to go to (for ex) `/getting-started/#vscode`.

Worth noting that editing the hash in your browser probably won't update, because we don't subscribe to it changing (we can do, but it seems pointless since no users will edit it like this). You'll just have to hit refresh when testing.

Also; there's a flash of Android Studio's content at page load because it's visible before this changes (I guess the same may be true for the OS one). There are options for fixing this, but I don't know if it's worthwhile.